### PR TITLE
list slack channels

### DIFF
--- a/.github/ISSUE_TEMPLATE/-onboarding--welcome-a-new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/-onboarding--welcome-a-new-team-member.md
@@ -44,7 +44,16 @@ Meet and greets with discipline leads to learn how your work might be related to
 - [ ] Senior Policy Advisor @mtoutloff 
 
 # Get access 👀
-- [ ] Slack channels, ask @foudamo
+- [ ] Slack channels as appropriate, ask @foudamo
+  - [ ] #notify
+  - [ ] #notify-community
+  - [ ] #notify-support
+  - [ ] #notify-dev
+  - [ ] #notify-team
+  - [ ] #notify-dev-team
+  - [ ] #notify-team-core
+  - [ ] #notification-ops
+  - [ ] #notification-staging-ops
 - [ ] Zenhub board, ask @foudamo
 - [ ] Miro, ask @adriannelee
 - [ ] Google Drive, ask anyone on the team

--- a/.github/ISSUE_TEMPLATE/-onboarding--welcome-a-new-team-member.md
+++ b/.github/ISSUE_TEMPLATE/-onboarding--welcome-a-new-team-member.md
@@ -51,6 +51,7 @@ Meet and greets with discipline leads to learn how your work might be related to
   - [ ] #notify-dev
   - [ ] #notify-team
   - [ ] #notify-dev-team
+  - [ ] #notify-team-app
   - [ ] #notify-team-core
   - [ ] #notification-ops
   - [ ] #notification-staging-ops


### PR DESCRIPTION
# Summary | Résumé

We forgot to add Ben to the #notify-community slack channel when he joined. There are so many Notify channels, I think it's good to explicitly list them in the onboarding card so we don't forget one next time.


