### PR TITLE
Add a new incident action item template for zenhub

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident-item
+++ b/.github/ISSUE_TEMPLATE/incident-item
@@ -1,0 +1,67 @@
+# 🔧 Incident Action Item
+
+## 🎯 Action Required
+
+**Description of Action Item:**  
+
+_What needs to be done to reduce risk, improve reliability, or prevent recurrence._
+
+**Type of Action:**  
+
+- [ ] Fix / Remediation  
+- [ ] Mitigation  
+- [ ] Hardening / Resilience  
+- [ ] Monitoring / Alerting  
+- [ ] Documentation Update  
+- [ ] Process / Governance  
+- [ ] Other: ___
+
+---
+
+## 🧵 Incident References
+
+**Incident Slack Channel:**  
+**Post-Mortem Document:**  
+
+---
+
+## 🎛 Current Mitigations in Place and Risk Assessment
+
+_Are there currently mitigations in place to prevent / reduce the risk of **not doing this task**. 
+
+Examples:
+
+- Guardrails put in place during incident response  
+- Temporary config updates  
+- Sending rate limits applied  
+- Monitoring added during/after incident  
+
+**Risk of Recurrence:**  
+
+- [ ] High  
+- [ ] Medium  
+- [ ] Low  
+
+**Potential Impact (if it happens again):**  
+
+- [ ] System stability
+- [ ] Notifications delivery
+- [ ] User experience
+- [ ] Security / privacy
+- [ ] Operational burden
+
+---
+
+## ✔️ Definition of Done
+
+- Clear remediation identified
+- Work implemented and tested
+- Documentation / runbooks updated (if needed)
+- Monitoring/alerts adjusted (if needed)
+- Risk owners confirm closure
+
+---
+
+## 📦 Additional Notes
+
+_Anything else reviewers or implementers should know._


### PR DESCRIPTION


# Summary | Résumé

Adding a template specific for incident action items, coordinated with Carolyn.

The zenhub template card for the incident action item template improves clarity and add sections for current mitigations and risk assessment.

# Test instructions | Instructions pour tester la modification

None but getting the team to review would be nice. 
