### PR TITLE
Fix the incident-item template

### DIFF
--- a/.github/ISSUE_TEMPLATE/incident-item.md
+++ b/.github/ISSUE_TEMPLATE/incident-item.md
@@ -1,3 +1,12 @@
+---
+name: Incident Action Item
+about: Track an action item resulting from an incident post-mortem
+title: '[Incident] '
+labels: ''
+assignees: ''
+
+---
+
 # 🔧 Incident Action Item
 
 ## 🎯 Action Required


### PR DESCRIPTION
# Summary | Résumé

The file was missing the `.md` extension and also missing the yaml metadata at the top.

